### PR TITLE
Add static analysis tools

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  API:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: itu-minitwit/Api/Api
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+        
+      - name: Format
+        run: dotnet format
+  

--- a/itu-minitwit/Api/Api/.editorconfig
+++ b/itu-minitwit/Api/Api/.editorconfig
@@ -7,10 +7,14 @@ indent_size = 4
 indent_style = space
 
 # Enable/disable specific StyleCop rules
-# Turn off XML doc requirement
+# Doesnt check for class headers
 dotnet_diagnostic.SA1633.severity = none
 dotnet_diagnostic.SA1600.severity = none
+# Doesnt check for code documentation
+dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1024.severity = none
+
 # Make ordering of using statements a warning
-dotnet_diagnostic.SA1200.severity = warning
+dotnet_diagnostic.SA1200.severity = suggestion
 # Treat missing file header as an error
 #dotnet_diagnostic.SA1633.severity = error

--- a/itu-minitwit/Api/Api/.editorconfig
+++ b/itu-minitwit/Api/Api/.editorconfig
@@ -8,6 +8,7 @@ indent_style = space
 
 # Enable/disable specific StyleCop rules
 # Turn off XML doc requirement
+dotnet_diagnostic.SA1633.severity = none
 dotnet_diagnostic.SA1600.severity = none
 # Make ordering of using statements a warning
 dotnet_diagnostic.SA1200.severity = warning

--- a/itu-minitwit/Api/Api/.editorconfig
+++ b/itu-minitwit/Api/Api/.editorconfig
@@ -1,0 +1,15 @@
+# Root of the editor config
+root = true
+
+# Use spaces instead of tabs
+[*.cs]
+indent_size = 4
+indent_style = space
+
+# Enable/disable specific StyleCop rules
+# Turn off XML doc requirement
+dotnet_diagnostic.SA1600.severity = none
+# Make ordering of using statements a warning
+dotnet_diagnostic.SA1200.severity = warning
+# Treat missing file header as an error
+#dotnet_diagnostic.SA1633.severity = error

--- a/itu-minitwit/Api/Api/Api.csproj
+++ b/itu-minitwit/Api/Api/Api.csproj
@@ -26,6 +26,10 @@
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
         <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.0" />

--- a/itu-minitwit/Api/Api/stylecop.json
+++ b/itu-minitwit/Api/Api/stylecop.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "documentationRules": {
+      "companyName": "NintendoLawyers",
+      "documentInternalElements": true
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "insideNamespace"
+    }
+  }
+}


### PR DESCRIPTION
Installed StyleCop and formatter

Stylecop uses syleCop.json and .editorconfig

Warnings will be shown when using 'dotnet build'

Format whil happen when using 'dotnet format'